### PR TITLE
Process cache logic asynchronously

### DIFF
--- a/github/github_query.go
+++ b/github/github_query.go
@@ -103,5 +103,5 @@ query topIndonesia {
 	%s
   }
 `,
-	generateSummaryQuery("topIndonesiaDev", "Indonesia", "*", ">=100", 25),
+	generateSummaryQuery("topIndonesiaDev", "Indonesia", "*", ">=100", 100),
 )


### PR DESCRIPTION
This should fix #10 😄 

The idea is, we will initialize cache before the app is started. Once the app is started, we will handle cache update asynchronously. Since there's only a single background worker `cacheJobs`, this will ensure we don't hit Github API limit by sending too much requests at a time. In addition, `make(chan string, 100)` means, we can afford a queue of up to 100 jobs, which shouldn't be a problem unless there are more than 100 requests while we try updating our cache (the next request needs to wait until cache update is done).

---

Tips: If you're not sure how this code works, try changing `time.Since(lastCache).Hours()` to `time.Since(lastCache).Seconds()` and try hitting the refresh button consecutively.